### PR TITLE
Add missing "host" to environment example

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ needed options:
 {
     "driver": "mysql",
     "protocol": "tcp",
+    "host": "localhost",
     "port": 3306,
     "user": "root",
     "password": "",


### PR DESCRIPTION
This way it is copy/pastable.